### PR TITLE
Add Missing SDRAM Peripheral Makefile Entry

### DIFF
--- a/rtl/fpga/Makefile
+++ b/rtl/fpga/Makefile
@@ -58,6 +58,7 @@ RTL_SOURCES = \
 	$(RTL_DIR)/memory/sram.sv \
 	$(RTL_DIR)/cpu/writeback_mux.sv \
 	$(RTL_DIR)/cpu/cpu.sv \
+	$(RTL_DIR)/peripherals/sdram_peripheral.sv \
 	$(RTL_DIR)/peripherals/sram_peripheral.sv \
 	$(RTL_DIR)/peripherals/gfx2d_peripheral.sv \
 	$(RTL_DIR)/peripherals/audiosys_peripheral.sv \


### PR DESCRIPTION
This change updates the fpga makefile to add the sdram peripheral which was previously missing. This was preventing the pocket fpga target from building successfully.